### PR TITLE
Improvements to line/assembly generation code

### DIFF
--- a/LineGenerator.cs
+++ b/LineGenerator.cs
@@ -30,7 +30,8 @@ namespace Diz.LogWriter
                     line += column;
             }
 
-            return line;
+            line = line.TrimEnd();
+            return String.IsNullOrEmpty(line) ? " " : line;
         }
 
         private string GenerateColumn(int offset, LogCreatorLineFormatter.ColumnFormat columnFormat, string overrideFormatterName = null)

--- a/LineGenerator.cs
+++ b/LineGenerator.cs
@@ -17,8 +17,7 @@ namespace Diz.LogWriter
             LogCreatorLineFormatter = new LogCreatorLineFormatter(formatStr, Generators);
         }
         
-        public string GenerateSpecialLine(string type, bool fullLine, int offset = -1) => GenerateLine(offset, fullLine, type);
-        public string GenerateSpecialLine(string type, int offset = -1) => GenerateLine(offset, true, type);
+        public string GenerateSpecialLine(string type, int offset = -1) => GenerateLine(offset, LogCreator.Settings.GenerateFullLine, type);
         public string GenerateNormalLine(int offset) => GenerateLine(offset);
 
         private string GenerateLine(int offset, bool generateFullLine = true, string overrideFormatterName = null)

--- a/LineGenerator.cs
+++ b/LineGenerator.cs
@@ -25,9 +25,9 @@ namespace Diz.LogWriter
             var line = "";
             foreach (var columnFormat in LogCreatorLineFormatter.ColumnFormats)
             {
-                line += GenerateColumn(offset, columnFormat, overrideFormatterName);
-                if (!generateFullLine && columnFormat.Value == "code")
-                    return line;
+                var column = GenerateColumn(offset, columnFormat, overrideFormatterName);
+                if (generateFullLine || (!generateFullLine && (columnFormat.Value == "label" || columnFormat.Value == "code" || string.IsNullOrWhiteSpace(column))))
+                    line += column;
             }
 
             return line;

--- a/LineGenerator.cs
+++ b/LineGenerator.cs
@@ -17,15 +17,18 @@ namespace Diz.LogWriter
             LogCreatorLineFormatter = new LogCreatorLineFormatter(formatStr, Generators);
         }
         
-        public string GenerateSpecialLine(string type, int offset = -1) => GenerateLine(offset, type);
+        public string GenerateSpecialLine(string type, bool fullLine, int offset = -1) => GenerateLine(offset, fullLine, type);
+        public string GenerateSpecialLine(string type, int offset = -1) => GenerateLine(offset, true, type);
         public string GenerateNormalLine(int offset) => GenerateLine(offset);
 
-        private string GenerateLine(int offset, string overrideFormatterName = null)
+        private string GenerateLine(int offset, bool generateFullLine = true, string overrideFormatterName = null)
         {
             var line = "";
             foreach (var columnFormat in LogCreatorLineFormatter.ColumnFormats)
             {
                 line += GenerateColumn(offset, columnFormat, overrideFormatterName);
+				if (!generateFullLine && columnFormat.Value == "code")
+                    return line;
             }
 
             return line;

--- a/LineGenerator.cs
+++ b/LineGenerator.cs
@@ -27,7 +27,7 @@ namespace Diz.LogWriter
             foreach (var columnFormat in LogCreatorLineFormatter.ColumnFormats)
             {
                 line += GenerateColumn(offset, columnFormat, overrideFormatterName);
-				if (!generateFullLine && columnFormat.Value == "code")
+                if (!generateFullLine && columnFormat.Value == "code")
                     return line;
             }
 

--- a/LineGenerator.cs
+++ b/LineGenerator.cs
@@ -72,7 +72,7 @@ namespace Diz.LogWriter
 
             return new LogCreatorLineFormatter.ColumnFormat
             {
-                LengthOverride = GetGeneratorFor(originalColumn.Value).DefaultLength,
+                LengthOverride = (originalColumn.LengthOverride != null) ? originalColumn.LengthOverride : GetGeneratorFor(originalColumn.Value).DefaultLength,
                 IgnoreOffset = ignoreOffset,
                 Value = val,
             };

--- a/LogCreator.cs
+++ b/LogCreator.cs
@@ -214,7 +214,7 @@ namespace Diz.LogWriter
             if (special == "empty" && !Settings.OutputExtraWhitespace)
                 return;
             
-            var output = LineGenerator.GenerateSpecialLine(special, offset); 
+            var output = LineGenerator.GenerateSpecialLine(special, Settings.GenerateFullLine, offset); 
             WriteLine(output);
         }
 

--- a/LogCreator.cs
+++ b/LogCreator.cs
@@ -214,7 +214,7 @@ namespace Diz.LogWriter
             if (special == "empty" && !Settings.OutputExtraWhitespace)
                 return;
             
-            var output = LineGenerator.GenerateSpecialLine(special, Settings.GenerateFullLine, offset); 
+            var output = LineGenerator.GenerateSpecialLine(special, offset); 
             WriteLine(output);
         }
 

--- a/assemblyGenerators/AssemblyGenerators.cs
+++ b/assemblyGenerators/AssemblyGenerators.cs
@@ -62,9 +62,10 @@ namespace Diz.LogWriter.assemblyGenerators
             LogCreator.OnLabelVisited(snesAddress);
 
             var noColon = label.Length == 0 || label[0] == '-' || label[0] == '+';
+            var newLine = (LogCreator.Settings.NewLine && !noColon) ? string.Format($"{Environment.NewLine}{{0,{length}}}", "") : "";
 
             var str = $"{label}{(noColon ? "" : ":")}";
-            return Util.LeftAlign(length, str);
+            return $"{Util.LeftAlign(length, str)}{newLine}";
         }
     }
 


### PR DESCRIPTION
This PR adds a boolean to the line generation code that toggles if a line should output anything after the %code% column on special lines. It also adds the ability to print labels on their own lines. Finally, this fixes length overrides so that org, map, and other special columns respect the users' formatting.

This PR fixes issue #1/issue [#93](https://github.com/IsoFrieze/DiztinGUIsh/issues/93) of DiztinGUIsh.